### PR TITLE
Added ConvertKit-Svelte reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@
   <p>Easily plug convertkit forms to your React and Gatsby websites.</p>
 </div>
 
+Using Vue? Try [ConvertKit-Vue](https://github.com/ConvertKit/convertkit-vue)
 
-Using Vue? Try [ConvertKit-Vue](https://npm.im/convertkit-vue)
+Using Svelte? Try [ConvertKit-Svelte](https://github.com/ConvertKit/convertkit-svelte)
+
 ## Setup
 
 ```sh


### PR DESCRIPTION
I considered adding a `_(coming very soon)_` label,  
but it would be easy to forget to update,  
so I left the minimal reference to encourage engagement with the new project